### PR TITLE
Optimize struct field order to reduce size from 136 bytes to 128 bytes

### DIFF
--- a/session.go
+++ b/session.go
@@ -42,11 +42,11 @@ type options struct {
 	sign                    []byte
 	cookieName              string
 	cookieLifeTime          int
-	secure                  bool
 	domain                  string
 	sameSite                http.SameSite
 	expired                 int64
 	sessionID               IDHandlerFunc
+	secure                  bool
 	enableSetCookie         bool
 	enableSIDInURLQuery     bool
 	enableSIDInHTTPHeader   bool


### PR DESCRIPTION
Reordered the fields in the Options struct to optimize memory alignment, reducing its size from **136** bytes to **128** bytes. This change improves memory efficiency.